### PR TITLE
Replace parent glyph with two dots

### DIFF
--- a/lisp/casual-dired.el
+++ b/lisp/casual-dired.el
@@ -94,19 +94,19 @@
 
    ["Navigation"
     :pad-keys t
-    ("^" "᳞ 📁" dired-up-directory :transient t)
-    ("p" "↑ 📄" dired-previous-line :transient t)
-    ("n" "↓ 📄" dired-next-line :transient t)
-    ("M-p" "↑ 📁" dired-prev-dirline
+    ("^" ".. 📁" dired-up-directory :transient t)
+    ("p" " ↑ 📄" dired-previous-line :transient t)
+    ("n" " ↓ 📄" dired-next-line :transient t)
+    ("M-p" " ↑ 📁" dired-prev-dirline
      :if-not casual-dired-lisp-dired-buffer-p
      :transient t)
-    ("M-n" "↓ 📁" dired-next-dirline
+    ("M-n" " ↓ 📁" dired-next-dirline
      :if-not casual-dired-lisp-dired-buffer-p
      :transient t)
-    ("[" "↑ 🗂️" dired-prev-subdir
+    ("[" " ↑ 🗂️" dired-prev-subdir
      :if-not casual-dired-lisp-dired-buffer-p
      :transient t)
-    ("]" "↓ 🗂️" dired-next-subdir
+    ("]" " ↓ 🗂️" dired-next-subdir
      :if-not casual-dired-lisp-dired-buffer-p
      :transient t)]]
 


### PR DESCRIPTION
- Done to support Linux and other platforms that can not render it.
