### PR TITLE
Minor Copy Edits

### DIFF
--- a/README.org
+++ b/README.org
@@ -46,6 +46,8 @@ If you use ~use-package~, here is the recipe for installing it.
     :bind (:map dired-mode-map ("C-o" . 'casual-dired-tmenu)))
 #+end_src
 
+In addition, you may wish to directly sort the Dired buffer by different criteria. Binding ~s~ (or one of your choosing) to ~casual-dired-sort-by-tmenu~ will accomplish this. Look below in the Configuration section to see how this can be done.
+
 Included is a standard keymap for Dired sorting commands (~casual-dired-sort-menu~) which can be included in a context menu for a mouse-driven workflow.
 
 #+begin_src elisp :lexical no

--- a/docs/developer.org
+++ b/docs/developer.org
@@ -40,7 +40,7 @@ Casual Dired uses the [[https://www.gnu.org/software/emacs/manual/html_node/ert/
 
 One can run a test for a single file by using a "phony" target with a suffix of ~.elt~ in the ~lisp/~ directory containing all the source files.
 
-For example, in the ~lisp/~ directory, run this command to exercise all tests for functions in ~casual-financial.el~.
+For example, in the ~lisp/~ directory, run this command to exercise all tests for functions in ~casual-dired-sort-by.el~.
 
 #+begin_src test
   $ make casual-dired-sort-by.elt


### PR DESCRIPTION
- Add guidance to bind `s` to `casual-dired-sort-by-menu` in `README.org`.
- Fix typo in `docs/developer.org`.