### PR TITLE
Remove extraneous code now in casual-lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ create-merge-development-branch			\
 create-pr					\
 create-release-pr				\
 create-release-tag				\
-create-gh-release
+create-gh-release				\
+status
 
 ## Run test regression
 tests:
@@ -124,3 +125,6 @@ create-release-tag: checkout-main
 
 create-gh-release: create-release-tag
 	gh release create -t v$(VERSION) --notes-from-tag $(VERSION)
+
+status:
+	git status

--- a/README.org
+++ b/README.org
@@ -159,11 +159,19 @@ If you enjoy using Casual Dired, consider making a modest financial contribution
 [[https://www.buymeacoffee.com/kickingvegas][file:docs/images/default-yellow.png]]
 
 * See Also
-If you like Casual Dired, these other projects might interest you:
+Casual Dired is part of a suite of porcelains for different Emacs packages.
 
-- [[https://github.com/kickingvegas/cc-isearch-menu][cc-isearch-menu]] - A Transient menu for isearch.
-- [[https://github.com/kickingvegas/casual][Casual]] - an opinionated Transient porcelain for Emacs Calc.
+To get all current and future Casual porcelains, please install [[https://github.com/kickingvegas/casual-suite][Casual Suite]] from [[https://melpa.org/#/casual-suite][MELPA]].
+
+Porcelains currently supported by Casual are listed below:
+
+- [[https://github.com/kickingvegas/casual-avy][Casual Avy]] - a Transient porcelain for [[https://github.com/abo-abo/avy][Avy]].
+- [[https://github.com/kickingvegas/casual-calc][Casual Calc]] - a Transient porcelain for [[https://www.gnu.org/software/emacs/manual/html_mono/calc.html][Calc]].
+- [[https://github.com/kickingvegas/casual-info][Casual Info]] - a Transient porcelain for the [[https://www.gnu.org/software/emacs/manual/html_node/info/][Info]] reader.  
+- [[https://github.com/kickingvegas/casual-isearch][Casual I-Search]] - a Transient menu for [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Incremental-Search.html][I-Search]].
+
+Users who prefer finer grained control over package installation can install each porcelain above individually.
 
 * Acknowledgments
-A heartfelt thanks to all the contributors to Dired and Transit. Casual Dired would not be possible without your efforts.
+A heartfelt thanks to all the contributors to Dired and [[https://github.com/magit/transient][Transient]]. Casual Dired would not be possible without your efforts.
 

--- a/lisp/casual-dired-utils.el
+++ b/lisp/casual-dired-utils.el
@@ -114,22 +114,5 @@ ASCII-range string."
           (casual-lib-quit-one)
           (casual-lib-quit-all)])
 
-;; Transient Navigation
-(transient-define-suffix casual-lib-quit-all ()
-  "Dismiss all menus."
-  :transient nil
-  :key "C-q"
-  :description "Dismiss"
-  (interactive)
-  (transient-quit-all))
-
-(transient-define-suffix casual-lib-quit-one ()
-  "Go back to previous menu."
-  :transient nil
-  :key "C-g"
-  :description "‹Back"
-  (interactive)
-  (transient-quit-one))
-
 (provide 'casual-dired-utils)
 ;;; casual-dired-utils.el ends here


### PR DESCRIPTION
- Removes extraneous code that now lives in casual-lib.
- Added makefile target "status"
- Copy edits on README.org
