### PR TITLE
Remove usage of casual-dired-use-unicode-symbols

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,7 +6,7 @@ An opinionated [[https://github.com/magit/transient][Transient]]-based user inte
 [[file:docs/images/casual-dired-screenshot.png]]
 
 * Motivation
-While highly functional, Dired has a steep learning curve as it relies on single-key bindings for many of its commands. Menus are a user interface (UI) affordance that offer users discoverability and recall that can lower Dired's learning curve. While menus are commonly associated with mouse-driven UI, the inclusion of Transient in Emacs core allows for a menu UI that is keyboard-driven. Casual Dired endeavors to offer this as many Emacs users prefer keyboard-driven workflows.
+While highly functional, Dired has a steep learning curve as it relies on single-key bindings for many of its commands. Menus are a user interface (UI) affordance that offer users discoverability and recognition that can lower Dired's learning curve. While menus are commonly associated with mouse-driven UI, the inclusion of Transient in Emacs core allows for a menu UI that is keyboard-driven. Casual Dired endeavors to offer this as many Emacs users prefer keyboard-driven workflows.
 
 ** Goals
 - To provide a keyboard-driven menu UI to Dired.

--- a/lisp/casual-dired.el
+++ b/lisp/casual-dired.el
@@ -126,7 +126,7 @@
                     (format "%s %s"
                             (casual-dired-format-arrow
                              (casual-dired-unicode-get :up-arrow)
-                             casual-dired-use-unicode-symbols)
+                             casual-lib-use-unicode)
                             (casual-dired-unicode-get :file)))
      :transient t)
 
@@ -135,7 +135,7 @@
                     (format "%s %s"
                             (casual-dired-format-arrow
                              (casual-dired-unicode-get :down-arrow)
-                             casual-dired-use-unicode-symbols)
+                             casual-lib-use-unicode)
                             (casual-dired-unicode-get :file)))
      :transient t)
     ("M-p" " ↑ 📁" dired-prev-dirline
@@ -144,7 +144,7 @@
                     (format "%s %s"
                             (casual-dired-format-arrow
                              (casual-dired-unicode-get :up-arrow)
-                             casual-dired-use-unicode-symbols)
+                             casual-lib-use-unicode)
                             (casual-dired-unicode-get :directory)))
      :transient t)
     ("M-n" " ↓ 📁" dired-next-dirline
@@ -153,7 +153,7 @@
                     (format "%s %s"
                             (casual-dired-format-arrow
                              (casual-dired-unicode-get :down-arrow)
-                             casual-dired-use-unicode-symbols)
+                             casual-lib-use-unicode)
                             (casual-dired-unicode-get :directory)))
      :transient t)
     ("[" " ↑ 🗂️" dired-prev-subdir
@@ -162,7 +162,7 @@
                     (format "%s %s"
                             (casual-dired-format-arrow
                              (casual-dired-unicode-get :up-arrow)
-                             casual-dired-use-unicode-symbols)
+                             casual-lib-use-unicode)
                             (casual-dired-unicode-get :subdir)))
      :transient t)
     ("]" " ↓ 🗂️" dired-next-subdir
@@ -171,7 +171,7 @@
                     (format "%s %s"
                             (casual-dired-format-arrow
                              (casual-dired-unicode-get :down-arrow)
-                             casual-dired-use-unicode-symbols)
+                             casual-lib-use-unicode)
                             (casual-dired-unicode-get :subdir)))
      :transient t)
     ("j" " → 📄…" dired-goto-file
@@ -179,7 +179,7 @@
                     (format "%s %s…"
                             (casual-dired-format-arrow
                              (casual-dired-unicode-get :goto)
-                             casual-dired-use-unicode-symbols)
+                             casual-lib-use-unicode)
                             (casual-dired-unicode-get :file)))
      :transient t)
     ("M-j" " → 🗂️…" dired-goto-subdir
@@ -187,7 +187,7 @@
                     (format "%s %s…"
                             (casual-dired-format-arrow
                              (casual-dired-unicode-get :goto)
-                             casual-dired-use-unicode-symbols)
+                             casual-lib-use-unicode)
                             (casual-dired-unicode-get :subdir)))
      :transient t)]]
 


### PR DESCRIPTION
Use casual-lib-use-unicode in its place.
