### PR TITLE
Merge development to main 20240930_222500

### DIFF
--- a/lisp/casual-dired-version.el
+++ b/lisp/casual-dired-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-dired-version "1.8.2"
+(defconst casual-dired-version "1.8.3-rc.1"
   "Casual Dired Version.")
 
 (defun casual-dired-version ()

--- a/lisp/casual-dired.el
+++ b/lisp/casual-dired.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-dired
 ;; Keywords: tools
-;; Version: 1.8.2
+;; Version: 1.8.3-rc.1
 ;; Package-Requires: ((emacs "29.1") (casual-lib "1.1.0"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Sync `Version:` commit with release tag for package build**
  This changes the build process to sync the package `Version:` field commit
  with the release tag. This is to support use-package :vc in the upcoming Emacs
  30 release.
  

- **Bump version to 1.8.3-rc.1**
  